### PR TITLE
fix: exit code when reporter file is not provided

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -262,7 +262,7 @@ var CoverageReporter = function (rootConfig, helper, logger, emitter) {
 
     if (!toDisk && reporterConfig.file === undefined) {
       report.execute(context)
-      return
+      return results
     }
 
     const mkdirIfNotExists = promisify(helper.mkdirIfNotExists)


### PR DESCRIPTION
Applying PR to return 0/non-0 results from coverage runs that's [currently unapplied on the original](https://github.com/karma-runner/karma-coverage/pull/486).